### PR TITLE
Add custom email template support

### DIFF
--- a/model/app_storage.go
+++ b/model/app_storage.go
@@ -18,17 +18,18 @@ type AppStorage interface {
 
 // AppData represents Application data information.
 type AppData struct {
-	ID           string    `bson:"_id" json:"id"` // TODO: use string?
-	Secret       string    `bson:"secret" json:"secret"`
-	Active       bool      `bson:"active" json:"active"`
-	Name         string    `bson:"name" json:"name"`
-	Description  string    `bson:"description" json:"description"`
-	Scopes       []string  `bson:"scopes" json:"scopes"`   // Scopes is the list of all allowed scopes. If it's empty, no limitations (opaque scope).
-	Offline      bool      `bson:"offline" json:"offline"` // Offline is a boolean value that indicates whether on not the app supports refresh tokens. Do not use refresh tokens with apps that does not have secure storage.
-	Type         AppType   `bson:"type" json:"type"`
-	RedirectURLs []string  `bson:"redirect_urls" json:"redirect_urls"` // RedirectURLs is the list of allowed urls where user will be redirected after successfull login. Useful not only for web apps, mobile and desktop apps could use custom scheme for that.
-	TFAStatus    TFAStatus `bson:"tfa_status" json:"tfa_status"`
-	DebugTFACode string    `bson:"debug_tfa_code" json:"debug_tfa_code"`
+	ID                   string    `bson:"_id" json:"id"` // TODO: use string?
+	Secret               string    `bson:"secret" json:"secret"`
+	Active               bool      `bson:"active" json:"active"`
+	Name                 string    `bson:"name" json:"name"`
+	Description          string    `bson:"description" json:"description"`
+	Scopes               []string  `bson:"scopes" json:"scopes"`   // Scopes is the list of all allowed scopes. If it's empty, no limitations (opaque scope).
+	Offline              bool      `bson:"offline" json:"offline"` // Offline is a boolean value that indicates whether on not the app supports refresh tokens. Do not use refresh tokens with apps that does not have secure storage.
+	Type                 AppType   `bson:"type" json:"type"`
+	RedirectURLs         []string  `bson:"redirect_urls" json:"redirect_urls"` // RedirectURLs is the list of allowed urls where user will be redirected after successfull login. Useful not only for web apps, mobile and desktop apps could use custom scheme for that.
+	TFAStatus            TFAStatus `bson:"tfa_status" json:"tfa_status"`
+	DebugTFACode         string    `bson:"debug_tfa_code" json:"debug_tfa_code"`
+	CustomEmailTemplates bool      `bson:"customEmailTemplates" json:"customEmailTemplates"`
 
 	// Authorization
 	AuthzWay       AuthorizationWay `bson:"authorization_way" json:"authorization_way"`
@@ -121,4 +122,11 @@ func (a AppData) Sanitized() AppData {
 	a.TokenPayloadServiceHttpSettings = TokenPayloadServiceHttpSettings{}
 	a.TokenPayloadServicePluginSettings = TokenPayloadServicePluginSettings{}
 	return a
+}
+
+func (a AppData) GetCustomEmailTemplatePath() string {
+	if a.CustomEmailTemplates {
+		return a.ID
+	}
+	return ""
 }

--- a/model/email_service.go
+++ b/model/email_service.go
@@ -2,7 +2,7 @@ package model
 
 // EmailService manages sending emails.
 type EmailService interface {
-	SendTemplateEmail(emailType EmailTemplateType, subject string, recipient string, data EmailData) error
+	SendTemplateEmail(emailType EmailTemplateType, path string, subject string, recipient string, data EmailData) error
 }
 
 type EmailTransport interface {

--- a/web/admin/users.go
+++ b/web/admin/users.go
@@ -257,8 +257,15 @@ func (ar *Router) GenerateNewResetTokenUser() http.HandlerFunc {
 			Host:  uu.String(),
 		}
 
+		app, err := ar.server.Storages().App.AppByID(resetData.AppID)
+		if err != nil {
+			ar.Error(w, err, http.StatusInternalServerError, "")
+			return
+		}
+
 		if err = ar.server.Services().Email.SendTemplateEmail(
 			model.EmailTemplateTypeResetPassword,
+			app.GetCustomEmailTemplatePath(),
 			"Reset Password",
 			user.Email,
 			model.EmailData{

--- a/web/api/2fa.go
+++ b/web/api/2fa.go
@@ -140,7 +140,7 @@ func (ar *Router) EnableTFA() http.HandlerFunc {
 			}
 
 			// And send OTP code for 2fa
-			if err := ar.sendOTPCode(user); err != nil {
+			if err := ar.sendOTPCode(app, user); err != nil {
 				ar.Error(w, ErrorAPIRequestUnableToSendOTP, http.StatusInternalServerError, err.Error(), "EnableTFA.sendOTP")
 				return
 			}
@@ -401,6 +401,7 @@ func (ar *Router) RequestDisabledTFA() http.HandlerFunc {
 
 		if err = ar.server.Services().Email.SendTemplateEmail(
 			model.EmailTemplateTypeResetPassword,
+			app.GetCustomEmailTemplatePath(),
 			"Disable Two-Factor Authentication",
 			d.Email,
 			model.EmailData{
@@ -497,6 +498,7 @@ func (ar *Router) RequestTFAReset() http.HandlerFunc {
 
 		if err = ar.server.Services().Email.SendTemplateEmail(
 			model.EmailTemplateTypeResetPassword,
+			app.GetCustomEmailTemplatePath(),
 			"Disable Two-Factor Authentication",
 			d.Email,
 			model.EmailData{
@@ -550,7 +552,7 @@ func (ar *Router) check2FA(appTFAStatus model.TFAStatus, serverTFAType model.TFA
 	return false, false, nil
 }
 
-func (ar *Router) sendTFACodeInSMS(phone, otp string) error {
+func (ar *Router) sendTFACodeInSMS(app model.AppData, phone, otp string) error {
 	if phone == "" {
 		return errors.New("unable to send SMS OTP, user has no phone number")
 	}
@@ -561,7 +563,7 @@ func (ar *Router) sendTFACodeInSMS(phone, otp string) error {
 	return nil
 }
 
-func (ar *Router) sendTFACodeOnEmail(user model.User, otp string) error {
+func (ar *Router) sendTFACodeOnEmail(app model.AppData, user model.User, otp string) error {
 	if user.TFAInfo.Email == "" {
 		return errors.New("unable to send email OTP, user has no email")
 	}
@@ -573,6 +575,7 @@ func (ar *Router) sendTFACodeOnEmail(user model.User, otp string) error {
 
 	if err := ar.server.Services().Email.SendTemplateEmail(
 		model.EmailTemplateTypeTFAWithCode,
+		app.GetCustomEmailTemplatePath(),
 		"One-time password",
 		user.TFAInfo.Email,
 		model.EmailData{

--- a/web/api/app_settings.go
+++ b/web/api/app_settings.go
@@ -21,6 +21,7 @@ type appSettings struct {
 	TfaResendTimeout            int             `json:"tfaResendTimeout"`
 	LoginWith                   model.LoginWith `json:"loginWith"`
 	FederatedProviders          []string        `json:"federatedProviders"`
+	CustomEmailTemplates        bool            `json:"customEmailTemplates"`
 }
 
 // GetAppSettings return app settings
@@ -53,6 +54,7 @@ func (ar *Router) GetAppSettings() http.HandlerFunc {
 			TfaResendTimeout:            ar.tfaResendTimeout,
 			LoginWith:                   ar.SupportedLoginWays,
 			FederatedProviders:          make([]string, 0, len(app.FederatedProviders)),
+			CustomEmailTemplates:        app.CustomEmailTemplates,
 		}
 
 		for k := range app.FederatedProviders {

--- a/web/api/invites.go
+++ b/web/api/invites.go
@@ -110,6 +110,7 @@ func (ar *Router) RequestInviteLink() http.HandlerFunc {
 
 			if err = ar.server.Services().Email.SendTemplateEmail(
 				model.EmailTemplateTypeInvite,
+				app.GetCustomEmailTemplatePath(),
 				"Invitation",
 				d.Email,
 				model.EmailData{

--- a/web/api/login.go
+++ b/web/api/login.go
@@ -181,7 +181,7 @@ func (ar *Router) LoginWithPassword() http.HandlerFunc {
 	}
 }
 
-func (ar *Router) sendOTPCode(user model.User) error {
+func (ar *Router) sendOTPCode(app model.AppData, user model.User) error {
 	// we don't need to send any code for FTA Type App, it uses TOTP and generated on client side with the app
 	if ar.tfaType != model.TFATypeApp {
 
@@ -196,9 +196,9 @@ func (ar *Router) sendOTPCode(user model.User) error {
 		}
 		switch ar.tfaType {
 		case model.TFATypeSMS:
-			return ar.sendTFACodeInSMS(user.TFAInfo.Phone, otp)
+			return ar.sendTFACodeInSMS(app, user.TFAInfo.Phone, otp)
 		case model.TFATypeEmail:
-			return ar.sendTFACodeOnEmail(user, otp)
+			return ar.sendTFACodeOnEmail(app, user, otp)
 		}
 
 	}
@@ -319,7 +319,7 @@ func (ar *Router) loginFlow(app model.AppData, user model.User, requestedScopes 
 	}
 
 	if require2FA && enabled2FA {
-		if err := ar.sendOTPCode(user); err != nil {
+		if err := ar.sendOTPCode(app, user); err != nil {
 			return AuthResponse{}, err
 		}
 	} else {

--- a/web/api/reset_password.go
+++ b/web/api/reset_password.go
@@ -65,7 +65,7 @@ func (ar *Router) RequestResetPassword() http.HandlerFunc {
 					return
 				}
 			} else {
-				if err := ar.sendOTPCode(user); err != nil {
+				if err := ar.sendOTPCode(app, user); err != nil {
 					ar.Error(w, ErrorAPIInternalServerError, http.StatusInternalServerError, err.Error(), "RequestResetPassword.SendOTPCode")
 					return
 				}
@@ -112,6 +112,7 @@ func (ar *Router) RequestResetPassword() http.HandlerFunc {
 
 		if err = ar.server.Services().Email.SendTemplateEmail(
 			model.EmailTemplateTypeResetPassword,
+			app.GetCustomEmailTemplatePath(),
 			"Reset Password",
 			d.Email,
 			model.EmailData{

--- a/web_apps_src/admin/src/components/ManagementScreen/Applications/GeneralSettingsForm.js
+++ b/web_apps_src/admin/src/components/ManagementScreen/Applications/GeneralSettingsForm.js
@@ -34,6 +34,7 @@ const ApplicationGeneralSettingsForm = (props) => {
   );
   const [tfaStatus, setTfaStatus] = useState(application.tfa_status || 'disabled');
   const [active, setActive] = useState(application.active || false);
+  const [customEmailTemplates, setCustomEmailTemplates] = useState(application.customEmailTemplates || false);
   const [debugTfaCode, setDebugTfaCode] = useState(application.debug_tfa_code || '');
   const [scopes, setScopes] = useState(application.scopes || []);
   const [userDefaultScopes, setUserDefaultScopes] = useState(application.new_user_default_scopes || []);
@@ -57,6 +58,7 @@ const ApplicationGeneralSettingsForm = (props) => {
     if (application.secret) setSecret(application.secret);
     if (application.tfa_status) setTfaStatus(application.tfa_status);
     if (application.active) setActive(application.active);
+    if (application.customEmailTemplates) setCustomEmailTemplates(application.customEmailTemplates);
     if (application.debug_tfa_code) setDebugTfaCode(application.debug_tfa_code);
     if (application.scopes) setScopes(application.scopes);
     if (application.new_user_default_scopes) setUserDefaultScopes(application.new_user_default_scopes);
@@ -100,6 +102,7 @@ const ApplicationGeneralSettingsForm = (props) => {
       scopes,
       secret,
       active,
+      customEmailTemplates,
       description,
       tfa_status: tfaStatus,
       redirect_urls: redirectUrls,
@@ -265,6 +268,9 @@ const ApplicationGeneralSettingsForm = (props) => {
           <Toggle label="Active" value={!!active} onChange={setActive} />
         )}
 
+        {!isExcluded('customEmailTemplates') && (
+          <Toggle label="Custom email templates" value={!!customEmailTemplates} onChange={setCustomEmailTemplates} />
+        )}
       </div>
 
       <footer className="iap-apps-form__footer">


### PR DESCRIPTION
To use custom email templates you have to enable `Custom email template` flag in App settings and create folder with `App.ID` name in `static/templates` or another storage that you use and copy all templates to this folder.