### PR TITLE
string app id

### DIFF
--- a/storage/mongo/app.go
+++ b/storage/mongo/app.go
@@ -39,16 +39,11 @@ type AppStorage struct {
 
 // AppByID returns app from MongoDB by ID.
 func (as *AppStorage) AppByID(id string) (model.AppData, error) {
-	hexID, err := primitive.ObjectIDFromHex(id)
-	if err != nil {
-		return model.AppData{}, err
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), as.timeout)
 	defer cancel()
 
 	var ad model.AppData
-	if err := as.coll.FindOne(ctx, bson.M{"_id": hexID.Hex()}).Decode(&ad); err != nil {
+	if err := as.coll.FindOne(ctx, bson.M{"_id": id}).Decode(&ad); err != nil {
 		return model.AppData{}, err
 	}
 	return ad, nil
@@ -109,15 +104,10 @@ func (as *AppStorage) FetchApps(filterString string, skip, limit int) ([]model.A
 
 // DeleteApp deletes app by id.
 func (as *AppStorage) DeleteApp(id string) error {
-	hexID, err := primitive.ObjectIDFromHex(id)
-	if err != nil {
-		return err
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), as.timeout)
 	defer cancel()
 
-	if _, err := as.coll.DeleteOne(ctx, bson.M{"_id": hexID.Hex()}); err != nil {
+	if _, err := as.coll.DeleteOne(ctx, bson.M{"_id": id}); err != nil {
 		return err
 	}
 	return nil
@@ -125,7 +115,7 @@ func (as *AppStorage) DeleteApp(id string) error {
 
 // CreateApp creates new app in MongoDB.
 func (as *AppStorage) CreateApp(app model.AppData) (model.AppData, error) {
-	if objID, err := primitive.ObjectIDFromHex(app.ID); err != nil || objID == primitive.NilObjectID {
+	if app.ID == "" {
 		app.ID = primitive.NewObjectID().Hex()
 	}
 
@@ -140,11 +130,6 @@ func (as *AppStorage) CreateApp(app model.AppData) (model.AppData, error) {
 
 // DisableApp disables app in MongoDB storage.
 func (as *AppStorage) DisableApp(app model.AppData) error {
-	hexID, err := primitive.ObjectIDFromHex(app.ID)
-	if err != nil {
-		return err
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), as.timeout)
 	defer cancel()
 
@@ -152,7 +137,7 @@ func (as *AppStorage) DisableApp(app model.AppData) error {
 	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
 
 	var ad model.AppData
-	if err := as.coll.FindOneAndUpdate(ctx, bson.M{"_id": hexID.Hex()}, update, opts).Decode(&ad); err != nil {
+	if err := as.coll.FindOneAndUpdate(ctx, bson.M{"_id": app.ID}, update, opts).Decode(&ad); err != nil {
 		return err
 	}
 	// maybe return updated data?
@@ -161,11 +146,6 @@ func (as *AppStorage) DisableApp(app model.AppData) error {
 
 // UpdateApp updates app in MongoDB storage.
 func (as *AppStorage) UpdateApp(appID string, newApp model.AppData) (model.AppData, error) {
-	hexID, err := primitive.ObjectIDFromHex(appID)
-	if err != nil {
-		return model.AppData{}, err
-	}
-
 	// use ID from the request if it's not set
 	if len(newApp.ID) == 0 {
 		newApp.ID = appID
@@ -178,7 +158,7 @@ func (as *AppStorage) UpdateApp(appID string, newApp model.AppData) (model.AppDa
 	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
 
 	var ad model.AppData
-	if err = as.coll.FindOneAndUpdate(ctx, bson.M{"_id": hexID.Hex()}, update, opts).Decode(&ad); err != nil {
+	if err := as.coll.FindOneAndUpdate(ctx, bson.M{"_id": appID}, update, opts).Decode(&ad); err != nil {
 		return model.AppData{}, err
 	}
 

--- a/web/api/app_middleware.go
+++ b/web/api/app_middleware.go
@@ -20,21 +20,22 @@ const (
 func (ar *Router) AppID() negroni.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		appID := strings.TrimSpace(r.Header.Get(HeaderKeyAppID))
+		if appID == "" {
+			appID = r.URL.Query().Get(QueryKeyAppID)
+		}
+
 		app, err := ar.server.Storages().App.ActiveAppByID(appID)
 		if err != nil {
-			appID := r.URL.Query().Get(QueryKeyAppID)
-			app, err = ar.server.Storages().App.ActiveAppByID(appID)
-			if err != nil {
-				err = fmt.Errorf("Error getting App by ID: %s", err)
-				ar.Error(rw, ErrorAPIRequestAppIDInvalid, http.StatusBadRequest, err.Error(), "AppID.AppFromContext")
-				return
-			}
+			err = fmt.Errorf("Error getting App by ID: %s", err)
+			ar.Error(rw, ErrorAPIRequestAppIDInvalid, http.StatusBadRequest, err.Error(), "AppID.AppFromContext")
+			return
 		}
 		ctx := context.WithValue(r.Context(), model.AppDataContextKey, app)
 		r = r.WithContext(ctx)
 		next.ServeHTTP(rw, r)
 	}
 }
+
 func (ar *Router) RemoveTrailingSlash() negroni.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		r.URL.Path = strings.TrimSuffix(r.URL.Path, "/")


### PR DESCRIPTION
Two reasons for this PR:

1. We shadow error from getting app by ID and always get empty app id error in case something was wrong with MongoDB.
2. We break backward compatibility with requirement that app id should be ObjectID's hex.